### PR TITLE
Run Ruff, Black, mypy and pyright from TASLabz#17

### DIFF
--- a/python-stubs/dolphin/utils.pyi
+++ b/python-stubs/dolphin/utils.pyi
@@ -1,56 +1,44 @@
-"""
-Module for various utilities
-"""
+"""Module for various utilities."""
 
 def get_script_dir() -> str:
-	"""
-	Gets the path to the Scripts dir
+    """
+    Gets the path to the Scripts dir.
 
-	:return: value as string
-	"""
+    :return: value as string
+    """
 
 def open_dir() -> str:
-	"""
-	Promtps the user to open a file using a QFileDialog
+    """
+    Promtps the user to open a file using a QFileDialog.
 
-	:return: value as string
-	"""
+    :return: value as string
+    """
 
-def start_framedump():
-	"""
-	Starts a framedump
-	"""
+def start_framedump() -> None:
+    """Starts a framedump."""
 
-def stop_framedump():
-	"""
-	Stops a framedump
-	"""
+def stop_framedump() -> None:
+    """Stops a framedump."""
 
 def is_framedumping() -> bool:
-	"""
-	Gets if a framedump is occuring
+    """
+    Gets if a framedump is occuring.
 
-	:return: value as bool
-	"""
+    :return: value as bool
+    """
 
-def start_audiodump():
-	"""
-	Starts an audiodump
-	"""
+def start_audiodump() -> None:
+    """Starts an audiodump."""
 
-def stop_audiodump():
-	"""
-	Stops an audiodump
-	"""
+def stop_audiodump() -> None:
+    """Stops an audiodump."""
 
 def is_audiodumping() -> bool:
-	"""
-	Gets if an audiodump is occuring
+    """
+    Gets if an audiodump is occuring.
 
-	:return: value as bool
-	"""
+    :return: value as bool
+    """
 
-def save_screenshot(filename = None):
-	"""
-	Saves a screenshot of the running game
-	"""
+def save_screenshot(filename: str | None = None) -> None:
+    """Saves a screenshot of the running game."""


### PR DESCRIPTION
`ruff python-stubs/dolphin/utils.pyi --fix --extend-select=PYI,N,Q,D --ignore=PYI021,D1,D203,D205,D212,D401`
`black python-stubs/dolphin/utils.pyi --line-length=100`
`mypy python-stubs/dolphin/utils.pyi --strict --python-version=3.8`
`npx pyright@1.1.300 python-stubs/dolphin/utils.pyi --pythonversion=3.8.5`

Unmixed tabs and spaces
Adds missing annotations
Follows pydocstyle docstring styleguide as selected in https://github.com/TASLabz/dolphin/pull/17